### PR TITLE
Add alternate computer down alert and config

### DIFF
--- a/web/app/controllers/__init__.py
+++ b/web/app/controllers/__init__.py
@@ -2,6 +2,7 @@
 from .alert import (
     send_critical_alert,
     send_primary_computer_alert,
+    send_alternate_computer_alert,
     send_daily_summary,
     send_weekly_summary,
     send_monthly_email,

--- a/web/app/controllers/alert.py
+++ b/web/app/controllers/alert.py
@@ -11,6 +11,12 @@ from app.utils.send_email import send_email
 from config import BaseConfig as CFG
 
 
+def _support_alert_recipients():
+    """Emails that receive all offline alerts (e.g. support@digacore.com)."""
+    raw = getattr(CFG, "ALERT_SUPPORT_EMAILS", None) or ""
+    return [e.strip() for e in raw.split(",") if e.strip()]
+
+
 def send_critical_alert():
     """
     CLI command for celery worker.
@@ -23,12 +29,11 @@ def send_critical_alert():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Select all the active locations (except connected to trial and deactivated companies)
+    # Select all the active locations (except deactivated companies; includes both Pro and Lite)
     locations: list[m.Location] = (
         m.Location.query.join(m.Company)
         .filter(
             m.Location.activated.is_(True),
-            m.Company.is_trial.is_(False),
             m.Company.activated.is_(True),
         )
         .all()
@@ -179,18 +184,16 @@ def send_primary_computer_alert():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Get all the active primary computers which downloaded last backup more than 2 hour ago
-    # and not more than 3 hours ago
+    # Get all active Pro primary computers offline for more than 3 hours
     all_primary_computers: list[m.Computer] = m.Computer.query.filter(
         m.Computer.activated.is_(True),
         m.Computer.device_role == m.DeviceRole.PRIMARY,
-        m.Computer.last_download_time.between(
-            current_east_time - timedelta(hours=3),
-            current_east_time - timedelta(hours=2),
-        ),
+        m.Computer.last_download_time.is_not(None),
+        m.Computer.last_download_time < current_east_time - timedelta(hours=3),
     ).all()
 
     for computer in all_primary_computers:
+        # Skip Lite primaries - they are handled by alternate_computer_alert (Lite has 1 computer/location)
         if not computer.location or not computer.company or computer.company.is_trial:
             continue
 
@@ -260,6 +263,127 @@ def send_primary_computer_alert():
             )
 
     logger.info("<---Finish sending primary computer down alerts--->")
+
+
+def send_alternate_computer_alert():
+    """
+    CLI command for celery worker.
+    Sends alerts to users when alternate computer (or Lite primary) has been offline for more than 3 hours.
+    Includes: (1) all alternate computers, (2) primary computers from Lite companies (Lite has 1 computer/location).
+    Sends for all devices offline > 3 hours (runs hourly).
+    """
+    current_east_time: datetime = CFG.offset_to_est(datetime.utcnow(), True)
+
+    logger.info(
+        "<---Start sending alternate computer down alerts. Time: {}--->",
+        datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+    )
+
+    # Get all active alternate computers offline > 3 hrs
+    all_alternate_computers: list[m.Computer] = m.Computer.query.filter(
+        m.Computer.activated.is_(True),
+        m.Computer.device_role == m.DeviceRole.ALTERNATE,
+        m.Computer.last_download_time.is_not(None),
+        m.Computer.last_download_time < current_east_time - timedelta(hours=3),
+    ).all()
+
+    # Lite companies have 1 computer/location (primary only) - include their primaries so Lite gets alerts
+    lite_primary_computers: list[m.Computer] = (
+        m.Computer.query.join(m.Company)
+        .filter(
+            m.Computer.activated.is_(True),
+            m.Computer.device_role == m.DeviceRole.PRIMARY,
+            m.Company.is_trial.is_(True),
+            m.Computer.last_download_time.is_not(None),
+            m.Computer.last_download_time < current_east_time - timedelta(hours=3),
+        )
+        .all()
+    )
+
+    # Combine and dedupe by computer id (primary alert handles Pro primaries separately)
+    seen_ids: set[int] = set()
+    all_computers_to_alert: list[m.Computer] = []
+    for comp in all_alternate_computers + lite_primary_computers:
+        if comp.id not in seen_ids:
+            seen_ids.add(comp.id)
+            all_computers_to_alert.append(comp)
+
+    for computer in all_computers_to_alert:
+        if not computer.location or not computer.company:
+            continue
+
+        # Get all the active users connected to the computer
+        connected_users: list[m.User] = []
+        all_company_users: list[m.User] = m.User.query.filter(
+            m.User.activated.is_(True), m.User.company_id == computer.company_id
+        ).all()
+
+        for user in all_company_users:
+            if user.permission == m.UserPermissionLevel.COMPANY:
+                connected_users.append(user)
+            elif (
+                computer.location.group
+                and user.permission == m.UserPermissionLevel.LOCATION_GROUP
+                and user.location_group[0].id == computer.location.group[0].id
+            ):
+                connected_users.append(user)
+            elif (
+                user.permission == m.UserPermissionLevel.LOCATION
+                and user.location[0].id == computer.location.id
+            ):
+                connected_users.append(user)
+            else:
+                continue
+
+        if not connected_users:
+            continue
+
+        recipients = [
+            user.email for user in connected_users if user.receive_alert_emails
+        ]
+        # Add support emails to receive all alternate computer alerts
+        recipients = list(set(recipients + _support_alert_recipients()))
+        if not recipients:
+            logger.debug(
+                "Alternate computer alert for {} was not sent. Reason: no users for receive emails was found",
+                computer.computer_name,
+            )
+            continue
+        try:
+            is_lite_primary = (
+                computer.company.is_trial and computer.device_role == m.DeviceRole.PRIMARY
+            )
+            send_email(
+                subject=f"ALERT! {'Computer' if is_lite_primary else 'Alternate computer'} {computer.computer_name} is down",
+                sender=CFG.MAIL_DEFAULT_SENDER,
+                recipients=recipients,
+                html=render_template(
+                    "email/alternate-computer-alert-email.html",
+                    location=computer.location,
+                    computer=computer,
+                    is_lite_primary=is_lite_primary,
+                ),
+            )
+
+            # Create record about new alert event
+            new_alert_event = m.AlertEvent(
+                location_id=computer.location.id,
+                alert_type=m.AlertEventType.ALTERNATE_COMPUTER_DOWN,
+            )
+            new_alert_event.save()
+
+            logger.info(
+                "Alternate computer down alert email sent for computer {}",
+                computer.computer_name,
+            )
+        except Exception as err:
+            logger.error(
+                "Alternate computer down alert email was not sent for computer {}. Error: {}",
+                computer.computer_name,
+                err,
+            )
+
+    logger.info("<---Finish sending alternate computer down alerts--->")
 
 
 def company_users_by_permission(
@@ -501,10 +625,9 @@ def send_daily_summary():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Select all the companies except global, trial and deactivated
+    # Select all the companies except global and deactivated (includes both Pro and Lite)
     companies: list[m.Company] = m.Company.query.filter(
         m.Company.is_global.is_(False),
-        m.Company.is_trial.is_(False),
         m.Company.activated.is_(True),
     ).all()
 
@@ -794,11 +917,10 @@ def send_monthly_email():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Select all the companies except global and deactivated
+    # Select all the companies except global and deactivated (includes both Pro and Lite)
     companies: list[m.Company] = m.Company.query.filter(
         m.Company.is_global.is_(False),
         m.Company.activated.is_(True),
-        m.Company.is_trial.is_(False),
     ).all()
 
     for company in companies:

--- a/web/app/models/alert_event.py
+++ b/web/app/models/alert_event.py
@@ -10,6 +10,7 @@ from app.models.utils import ModelMixin
 
 class AlertEventType(enum.Enum):
     PRIMARY_COMPUTER_DOWN = "PRIMARY_COMPUTER_DOWN"
+    ALTERNATE_COMPUTER_DOWN = "ALTERNATE_COMPUTER_DOWN"
     CRITICAL_ALERT = "CRITICAL_ALERT"
 
 

--- a/web/app/templates/email/alternate-computer-alert-email.html
+++ b/web/app/templates/email/alternate-computer-alert-email.html
@@ -1,0 +1,44 @@
+{% extends "email/base-email.html" %} {% import "email/base-email-macros.html"
+as macros%} {% block content_tag %} {{ macros.tag("white", "red", "eMAR Computer
+Offline") }} {% endblock %} {% block content %}
+<p
+  style="
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 20px 0 0 0;
+    text-align: left;
+  "
+>
+  Location: {{ location.name }}
+</p>
+
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
+  Computer: {{ computer.computer_name }}
+</p>
+
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
+  Error: {{ "Unsuccessful backup" if computer.download_status == "error" else
+  "Device is offline" }}
+</p>
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
+  Device placed : {{ computer.device_location }}
+</p>
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
+  Last Backup Time: {{ computer.last_download_time.strftime("%Y-%m-%d %H:%M:%S")
+  if computer.last_download_time else "-"}}
+</p>
+
+<p style="font-size: 1rem; line-height: 1.5rem; text-align: left">
+  The {{ "computer" if is_lite_primary else "alternate computer" }} <b>{{ computer.computer_name }}</b> at
+  <b>{{ location.name }}</b> has been offline for over 3 hours and did not download the
+  latest eMAR backup file.
+</p>
+
+<hr style="margin: 20px 0; border: 1px solid #dcdee4" />
+
+{{ macros.button("eMAR Vault", url_for("main.index")) }}
+
+<p style="font-size: 0.75rem; line-height: 1rem">
+  Login to the eMAR Vault to check the status of your computers.
+</p>
+{% endblock %}

--- a/web/config.py
+++ b/web/config.py
@@ -36,6 +36,7 @@ class BaseConfig(object):
     SUPPORT_EMAIL = os.environ.get("SUPPORT_EMAIL")
     SUPPORT_SALES_EMAIL = os.environ.get("SUPPORT_SALES_EMAIL")
     TO_ADDRESSES = os.environ.get("TO_ADDRESSES")
+    ALERT_SUPPORT_EMAILS = os.environ.get("ALERT_SUPPORT_EMAILS", "")
 
     # set optional bootswatch theme
     FLASK_ADMIN_SWATCH = "cerulean"

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - FLASK_ENV=production
       - FLASK_APP=wsgi:app
+      - ALERT_SUPPORT_EMAILS=${ALERT_SUPPORT_EMAILS}
     ports:
       - 127.0.0.1:${APP_PORT}:5000
     entrypoint: "bash start_server.sh"
@@ -64,6 +65,7 @@ services:
       - FLASK_ENV=production
       - FLASK_APP=wsgi:app
       - FLASK_DEBUG=1
+      - ALERT_SUPPORT_EMAILS=${ALERT_SUPPORT_EMAILS}
     depends_on:
       - db
     volumes:

--- a/web/file_api/drizzle/schema.ts
+++ b/web/file_api/drizzle/schema.ts
@@ -24,6 +24,7 @@ const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
 
 export const alerteventtype = pgEnum("alerteventtype", [
   "PRIMARY_COMPUTER_DOWN",
+  "ALTERNATE_COMPUTER_DOWN",
   "CRITICAL_ALERT",
 ]);
 export const backuplogtype = pgEnum("backuplogtype", [

--- a/web/migrations/versions/a1b2c3d4e5f6_add_alternate_computer_down_alert_type.py
+++ b/web/migrations/versions/a1b2c3d4e5f6_add_alternate_computer_down_alert_type.py
@@ -1,0 +1,25 @@
+"""add ALTERNATE_COMPUTER_DOWN to alerteventtype
+
+Revision ID: a1b2c3d4e5f6
+Revises: bcac2a6a1c71
+Create Date: 2026-02-03
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "bcac2a6a1c71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add new value to existing PostgreSQL enum (cannot remove enum values in downgrade easily)
+    op.execute("ALTER TYPE alerteventtype ADD VALUE 'ALTERNATE_COMPUTER_DOWN'")
+
+
+def downgrade():
+    # PostgreSQL does not support removing enum values; no-op
+    pass

--- a/web/sample.env
+++ b/web/sample.env
@@ -34,6 +34,9 @@ ALERT_PERIOD=600
 SUPPORT_EMAIL=set@email
 SUPPORT_SALES_EMAIL=set@sales
 
+# Comma-separated emails that receive all offline alerts (e.g. support@digacore.com)
+ALERT_SUPPORT_EMAILS=support@digacore.com
+
 SUPERPASS=setpass
 
 EXPIRATION_TIME_JWT_AND_SESSION=60

--- a/web/worker.py
+++ b/web/worker.py
@@ -46,6 +46,16 @@ def setup_periodic_tasks(sender, **kwargs):
     )
     entry.save()
 
+    # Alert when alternate computer has been offline > 3 hrs - run every hour
+    interval = crontab(minute=0)
+    entry = RedBeatSchedulerEntry(
+        "alternate_computer_alert_email",
+        "worker.alternate_computer_alert_email",
+        interval,
+        app=app,
+    )
+    entry.save()
+
     # Send daily summary - run every day at 11:00 AM (EST)
     interval = crontab(hour=11, minute=0)
     entry = RedBeatSchedulerEntry(
@@ -92,6 +102,12 @@ def critical_alert_email():
 @app.task
 def primary_computer_alert_email():
     flask_proc = subprocess.Popen(["flask", "primary-computer-alert-email"])
+    flask_proc.communicate()
+
+
+@app.task
+def alternate_computer_alert_email():
+    flask_proc = subprocess.Popen(["flask", "alternate-computer-alert-email"])
     flask_proc.communicate()
 
 

--- a/web/wsgi.py
+++ b/web/wsgi.py
@@ -113,6 +113,13 @@ def primary_computer_alert_email():
 
 
 @app.cli.command()
+def alternate_computer_alert_email():
+    from app.controllers import send_alternate_computer_alert
+
+    send_alternate_computer_alert()
+
+
+@app.cli.command()
 def daily_summary_email():
     from app.controllers import send_daily_summary
 


### PR DESCRIPTION
Introduce alerts for alternate computers (and Lite-company primaries) offline >3 hours: add send_alternate_computer_alert controller, email template, and CLI/worker task. Add ALERT_SUPPORT_EMAILS config + sample.env and docker-compose env passthrough so support addresses always receive alternate-computer alerts. Update primary alert logic to skip Lite primaries (handled by the new flow) and broaden company selection to include both Pro and Lite. Add AlertEventType.ALTERNATE_COMPUTER_DOWN enum (model, drizzle schema) and an Alembic migration to add the PostgreSQL enum value. Update worker schedule to run the new alert hourly and expose a new CLI command to trigger it.