### PR TITLE
Add global alert settings and pause alerts

### DIFF
--- a/web/app/__init__.py
+++ b/web/app/__init__.py
@@ -55,6 +55,7 @@ def create_app(environment="development"):
         billing_blueprint,
         computer_settings_blueprint,
         download_csv_blueprint,
+        alert_setup_blueprint,
     )
     from app.api import (
         downloads_info_blueprint,
@@ -124,6 +125,7 @@ def create_app(environment="development"):
     app.register_blueprint(billing_blueprint)
     app.register_blueprint(computer_settings_blueprint)
     app.register_blueprint(download_csv_blueprint)
+    app.register_blueprint(alert_setup_blueprint)
 
     # Register api.
     app.register_api(downloads_info_blueprint)

--- a/web/app/controllers/alert.py
+++ b/web/app/controllers/alert.py
@@ -12,8 +12,17 @@ from config import BaseConfig as CFG
 
 
 def _support_alert_recipients():
-    """Emails that receive all offline alerts (e.g. support@digacore.com)."""
-    raw = getattr(CFG, "ALERT_SUPPORT_EMAILS", None) or ""
+    """Emails that receive all offline alerts (e.g. support@digacore.com).
+    Reads from AlertSettings in DB first; falls back to ALERT_SUPPORT_EMAILS env.
+    """
+    try:
+        settings = m.AlertSettings.query.get(1)
+        if settings and settings.support_emails:
+            raw = settings.support_emails
+        else:
+            raw = getattr(CFG, "ALERT_SUPPORT_EMAILS", None) or ""
+    except Exception:
+        raw = getattr(CFG, "ALERT_SUPPORT_EMAILS", None) or ""
     return [e.strip() for e in raw.split(",") if e.strip()]
 
 
@@ -184,17 +193,17 @@ def send_primary_computer_alert():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Get all active Pro primary computers offline for more than 3 hours
+    # Get all active Pro primary computers offline for more than 3 hours (exclude paused)
     all_primary_computers: list[m.Computer] = m.Computer.query.filter(
         m.Computer.activated.is_(True),
         m.Computer.device_role == m.DeviceRole.PRIMARY,
+        m.Computer.alerts_paused.is_(False),
         m.Computer.last_download_time.is_not(None),
         m.Computer.last_download_time < current_east_time - timedelta(hours=3),
     ).all()
 
     for computer in all_primary_computers:
-        # Skip Lite primaries - they are handled by alternate_computer_alert (Lite has 1 computer/location)
-        if not computer.location or not computer.company or computer.company.is_trial:
+        if not computer.location or not computer.company:
             continue
 
         # Get all the active users connected to the computer
@@ -226,6 +235,8 @@ def send_primary_computer_alert():
         recipients = [
             user.email for user in connected_users if user.receive_alert_emails
         ]
+        # Add support emails to receive all primary computer alerts
+        recipients = list(set(recipients + _support_alert_recipients()))
         if not recipients:
             logger.debug(
                 "Critical alert email for primary computer {} was not sent. Reason: no users for receive emails was found",
@@ -241,6 +252,7 @@ def send_primary_computer_alert():
                     "email/primary-computer-alert-email.html",
                     location=computer.location,
                     computer=computer,
+                    company=computer.company,
                 ),
             )
 
@@ -268,9 +280,9 @@ def send_primary_computer_alert():
 def send_alternate_computer_alert():
     """
     CLI command for celery worker.
-    Sends alerts to users when alternate computer (or Lite primary) has been offline for more than 3 hours.
-    Includes: (1) all alternate computers, (2) primary computers from Lite companies (Lite has 1 computer/location).
-    Sends for all devices offline > 3 hours (runs hourly).
+    Sends alerts to users when alternate computer (Pro only) has been offline for more than 3 hours.
+    Lite companies are excluded - they only have primary computers, handled by primary_computer_alert.
+    Sends for all Pro alternate devices offline > 3 hours (runs hourly).
     """
     current_east_time: datetime = CFG.offset_to_est(datetime.utcnow(), True)
 
@@ -279,36 +291,21 @@ def send_alternate_computer_alert():
         datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
     )
 
-    # Get all active alternate computers offline > 3 hrs
-    all_alternate_computers: list[m.Computer] = m.Computer.query.filter(
-        m.Computer.activated.is_(True),
-        m.Computer.device_role == m.DeviceRole.ALTERNATE,
-        m.Computer.last_download_time.is_not(None),
-        m.Computer.last_download_time < current_east_time - timedelta(hours=3),
-    ).all()
-
-    # Lite companies have 1 computer/location (primary only) - include their primaries so Lite gets alerts
-    lite_primary_computers: list[m.Computer] = (
+    # Get all active Pro alternate computers offline > 3 hrs (exclude Lite and paused)
+    all_alternate_computers: list[m.Computer] = (
         m.Computer.query.join(m.Company)
         .filter(
             m.Computer.activated.is_(True),
-            m.Computer.device_role == m.DeviceRole.PRIMARY,
-            m.Company.is_trial.is_(True),
+            m.Computer.device_role == m.DeviceRole.ALTERNATE,
+            m.Computer.alerts_paused.is_(False),
+            m.Company.is_trial.is_(False),
             m.Computer.last_download_time.is_not(None),
             m.Computer.last_download_time < current_east_time - timedelta(hours=3),
         )
         .all()
     )
 
-    # Combine and dedupe by computer id (primary alert handles Pro primaries separately)
-    seen_ids: set[int] = set()
-    all_computers_to_alert: list[m.Computer] = []
-    for comp in all_alternate_computers + lite_primary_computers:
-        if comp.id not in seen_ids:
-            seen_ids.add(comp.id)
-            all_computers_to_alert.append(comp)
-
-    for computer in all_computers_to_alert:
+    for computer in all_alternate_computers:
         if not computer.location or not computer.company:
             continue
 
@@ -350,18 +347,15 @@ def send_alternate_computer_alert():
             )
             continue
         try:
-            is_lite_primary = (
-                computer.company.is_trial and computer.device_role == m.DeviceRole.PRIMARY
-            )
             send_email(
-                subject=f"ALERT! {'Computer' if is_lite_primary else 'Alternate computer'} {computer.computer_name} is down",
+                subject=f"ALERT! Alternate computer {computer.computer_name} is down",
                 sender=CFG.MAIL_DEFAULT_SENDER,
                 recipients=recipients,
                 html=render_template(
                     "email/alternate-computer-alert-email.html",
                     location=computer.location,
                     computer=computer,
-                    is_lite_primary=is_lite_primary,
+                    company=computer.company,
                 ),
             )
 

--- a/web/app/forms/alert_settings.py
+++ b/web/app/forms/alert_settings.py
@@ -1,0 +1,7 @@
+from flask_wtf import FlaskForm
+from wtforms import TextAreaField, SubmitField
+
+
+class AlertSettingsForm(FlaskForm):
+    support_emails = TextAreaField("Support emails")
+    submit = SubmitField("Save")

--- a/web/app/models/__init__.py
+++ b/web/app/models/__init__.py
@@ -16,6 +16,7 @@ from .pcc_daily_request import PCCDailyRequest
 from .location_group import LocationGroup, LocationGroupView
 from .download_backup_call import DownloadBackupCall
 from .alert_event import AlertEvent, AlertEventType
+from .alert_settings import AlertSettings
 from .telemetry_settings import TelemetrySettings
 from .computer_settings_link_table import ComputerSettingsLinkTable
 from .location_settings_link_table import LocationSettingsLinkTable

--- a/web/app/models/alert_settings.py
+++ b/web/app/models/alert_settings.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from app import db
+from app.models.utils import ModelMixin
+
+
+class AlertSettings(db.Model, ModelMixin):
+    """
+    Global alert configuration (single row).
+    Support emails receive all offline alerts (critical, primary, alternate).
+    Falls back to ALERT_SUPPORT_EMAILS env var when empty.
+    """
+
+    __tablename__ = "alert_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    support_emails = db.Column(db.Text, nullable=True, default="")
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<AlertSettings id={self.id}>"

--- a/web/app/models/computer.py
+++ b/web/app/models/computer.py
@@ -112,6 +112,9 @@ class Computer(db.Model, ModelMixin, SoftDeleteMixin, ActivatedMixin):
     files_checksum = db.Column(JSON)
 
     logs_enabled = db.Column(db.Boolean, server_default=sql.true(), default=True)
+    alerts_paused = db.Column(
+        db.Boolean, server_default=sql.text("false"), default=False, nullable=False
+    )
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     computer_ip = db.Column(db.String(128))
 
@@ -289,7 +292,7 @@ class Computer(db.Model, ModelMixin, SoftDeleteMixin, ActivatedMixin):
         # Not activated status
         if not self.activated:
             return ComputerStatus.NOT_ACTIVATED
-        # If computer downloaded backup less than 1 hour ago - it is ONLINE
+        # If computer downloaded backup within the recent-backup window (1.5h) - it is ONLINE
         elif (
             db.session.query(Computer)
             .filter(
@@ -301,7 +304,7 @@ class Computer(db.Model, ModelMixin, SoftDeleteMixin, ActivatedMixin):
             .first()
         ):
             return ComputerStatus.ONLINE
-        # If computer downloaded backup more than 1 hour ago but was online less than 10 minutes ago - ONLINE_NO_BACKUP
+        # If computer downloaded backup longer ago but was online less than 10 minutes ago - ONLINE_NO_BACKUP
         elif (
             db.session.query(Computer)
             .filter(
@@ -511,6 +514,7 @@ class ComputerView(RowActionListMixin, MyModelView):
         "device_role",
         "device_location",
         "device_type",
+        "alerts_paused",
         "last_download_time",
         "last_time_online",
         "computer_ip",
@@ -538,6 +542,7 @@ class ComputerView(RowActionListMixin, MyModelView):
         "notes",
         "computer_name",
         "activated",
+        "alerts_paused",
         "logs_enabled",
         "sftp_host",
         "sftp_port",
@@ -578,6 +583,8 @@ class ComputerView(RowActionListMixin, MyModelView):
     column_searchable_list = searchable_sortable_list
     column_sortable_list = searchable_sortable_list
     column_filters = searchable_sortable_list
+
+    column_editable_list = ["alerts_paused"]
 
     # NOTE allows edit in list view, but has troubles with permissions
     # column_editable_list = [
@@ -630,6 +637,7 @@ class ComputerView(RowActionListMixin, MyModelView):
         "current_msi_version": {"label": "Current msi version"},
         "manager_host": {"label": "Manager host"},
         "activated": {"label": "Activated"},
+        "alerts_paused": {"label": "Pause alerts"},
         "logs_enabled:": {"label": "Logs enabled"},
         "download_status": {"label": "Download status"},
         "last_download_time": {"label": "Last download time"},

--- a/web/app/templates/alert_setup/index.html
+++ b/web/app/templates/alert_setup/index.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container-fluid">
+  <h1 class="h3 mb-4 text-gray-800">Alert Setup</h1>
+
+  <div class="card shadow mb-4">
+    <div class="card-header py-3">
+      <h6 class="m-0 font-weight-bold text-primary">Alert Types</h6>
+    </div>
+    <div class="card-body">
+      <p class="text-gray-700">
+        eMAR Vault sends the following alerts when devices or locations go offline:
+      </p>
+      <ul>
+        <li><strong>Critical alert</strong> – When an entire location is offline (all computers at that location)</li>
+        <li><strong>Primary computer down</strong> – When the primary backup computer at a location has been offline for more than 3 hours</li>
+        <li><strong>Alternate computer down</strong> – When an alternate backup computer has been offline for more than 3 hours</li>
+        <li><strong>Daily / Weekly / Monthly summaries</strong> – Periodic reports of offline devices</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card shadow mb-4">
+    <div class="card-header py-3">
+      <h6 class="m-0 font-weight-bold text-primary">Configure Who Receives Alerts</h6>
+    </div>
+    <div class="card-body">
+      <p class="text-gray-700 mb-3">
+        Control alert delivery from these pages:
+      </p>
+      <ul class="list-unstyled">
+        <li class="mb-2">
+          <a href="{{ url_for('user.index_view') }}">User settings</a>
+          – Enable or disable "Receive Alerts emails" per user (Company/Location admins)
+        </li>
+        <li>
+          <a href="{{ url_for('computer.index_view') }}">Computer list</a>
+          – Pause alerts for specific computers (e.g. during maintenance)
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="card shadow mb-4">
+    <div class="card-header py-3">
+      <h6 class="m-0 font-weight-bold text-primary">Support Emails (Global Admins)</h6>
+    </div>
+    <div class="card-body">
+      <p class="text-gray-700 mb-3">
+        These emails receive all offline alerts (critical, primary, alternate) in addition to company/location recipients.
+        Use comma-separated values. Leave empty to use the <code>ALERT_SUPPORT_EMAILS</code> environment variable.
+      </p>
+      <form method="post" action="{{ url_for('alert_setup.index') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <div class="form-group">
+          <label for="support_emails">Support emails</label>
+          <textarea
+            class="form-control"
+            id="support_emails"
+            name="support_emails"
+            rows="3"
+            placeholder="support@example.com, ops@example.com"
+          >{{ form.support_emails.data or '' }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/web/app/templates/base.html
+++ b/web/app/templates/base.html
@@ -224,6 +224,11 @@
               <a class="collapse-item" href="/admin/desktopclient/"
                 >Download MSI</a
               >
+              {% if current_user.permission.value == "GLOBAL" and current_user.role.value == "ADMIN" %}
+              <a class="collapse-item" href="{{ url_for('alert_setup.index') }}"
+                >Alert setup</a
+              >
+              {% endif %}
               {% if current_user.permission.value == "GLOBAL" %}
               <a class="collapse-item" href="/admin/clientversion/"
                 >Client Version</a

--- a/web/app/templates/email/alternate-computer-alert-email.html
+++ b/web/app/templates/email/alternate-computer-alert-email.html
@@ -9,6 +9,10 @@ Offline") }} {% endblock %} {% block content %}
     text-align: left;
   "
 >
+  Company: {{ company.name if company else "-" }}
+</p>
+
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
   Location: {{ location.name }}
 </p>
 
@@ -29,7 +33,7 @@ Offline") }} {% endblock %} {% block content %}
 </p>
 
 <p style="font-size: 1rem; line-height: 1.5rem; text-align: left">
-  The {{ "computer" if is_lite_primary else "alternate computer" }} <b>{{ computer.computer_name }}</b> at
+  The alternate computer <b>{{ computer.computer_name }}</b> at
   <b>{{ location.name }}</b> has been offline for over 3 hours and did not download the
   latest eMAR backup file.
 </p>

--- a/web/app/templates/email/primary-computer-alert-email.html
+++ b/web/app/templates/email/primary-computer-alert-email.html
@@ -9,6 +9,10 @@ Offline") }} {% endblock %} {% block content %}
     text-align: left;
   "
 >
+  Company: {{ company.name if company else "-" }}
+</p>
+
+<p style="font-size: 1rem; font-weight: 600; margin: 0; text-align: left">
   Location: {{ location.name }}
 </p>
 

--- a/web/app/views/__init__.py
+++ b/web/app/views/__init__.py
@@ -10,3 +10,4 @@ from .merge import merge_blueprint
 from .billing import billing_blueprint
 from .computer_settings import computer_settings_blueprint
 from .download_csv import download_csv_blueprint
+from .alert_setup import alert_setup_blueprint

--- a/web/app/views/alert_setup.py
+++ b/web/app/views/alert_setup.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from app import db
+from app.forms.alert_settings import AlertSettingsForm
+from app.models import AlertSettings
+from app.models.user import UserPermissionLevel, UserRole
+
+alert_setup_blueprint = Blueprint("alert_setup", __name__, url_prefix="/alert-setup")
+
+
+@alert_setup_blueprint.route("/", methods=["GET", "POST"])
+@login_required
+def index():
+    if (
+        current_user.permission != UserPermissionLevel.GLOBAL
+        or current_user.role != UserRole.ADMIN
+    ):
+        flash("You don't have permission to access Alert setup.", "danger")
+        return redirect(url_for("main.index"))
+
+    settings = AlertSettings.query.get(1)
+    if not settings:
+        settings = AlertSettings(id=1, support_emails="")
+        db.session.add(settings)
+        db.session.commit()
+
+    form = AlertSettingsForm(obj=settings)
+
+    if form.validate_on_submit():
+        settings.support_emails = form.support_emails.data or ""
+        db.session.commit()
+        flash("Alert settings saved successfully.", "success")
+        return redirect(url_for("alert_setup.index"))
+
+    return render_template(
+        "alert_setup/index.html",
+        form=form,
+        settings=settings,
+    )

--- a/web/file_api/drizzle/schema.ts
+++ b/web/file_api/drizzle/schema.ts
@@ -542,6 +542,7 @@ export const computers = pgTable(
     }),
     notes: text(),
     deviceLocation: varchar("device_location", { length: 64 }),
+    alertsPaused: boolean("alerts_paused").default(false),
   },
   (table) => [
     foreignKey({

--- a/web/file_api/routes/last-time.ts
+++ b/web/file_api/routes/last-time.ts
@@ -92,15 +92,27 @@ export const lastTime = async (req: Request) => {
     updateData.lastDownloadTime = now;
   }
 
-  db.update(computers)
-    .set(updateData)
-    .where(eq(computers.id, computer.id))
-    .catch((err) =>
-      logger.error(
-        { err, computer: computer.id },
-        "Failed to update computer timestamps"
-      )
+  try {
+    await db
+      .update(computers)
+      .set(updateData)
+      .where(eq(computers.id, computer.id));
+  } catch (err) {
+    logger.error(
+      { err, computer: computer.id },
+      "Failed to update computer timestamps"
     );
+    return new Response(
+      JSON.stringify({
+        status: "fail",
+        message: "Failed to save timestamps",
+      } as LastTimeResponse),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
 
   // Get MSI version - optimized to avoid loading blob
   const msi = await (async () => {

--- a/web/migrations/versions/b2c3d4e5f6a7_add_alerts_paused_to_computers.py
+++ b/web/migrations/versions/b2c3d4e5f6a7_add_alerts_paused_to_computers.py
@@ -1,0 +1,32 @@
+"""add alerts_paused to computers
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-02-15
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "computers",
+        sa.Column(
+            "alerts_paused",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("computers", "alerts_paused")

--- a/web/migrations/versions/c3d4e5f6a7b8_add_alert_settings.py
+++ b/web/migrations/versions/c3d4e5f6a7b8_add_alert_settings.py
@@ -1,0 +1,36 @@
+"""add alert_settings table
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-02-02
+
+"""
+from alembic import op
+from sqlalchemy import text
+import sqlalchemy as sa
+
+
+revision = "c3d4e5f6a7b8"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "alert_settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("support_emails", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            "INSERT INTO alert_settings (id, support_emails, updated_at) VALUES (1, '', CURRENT_TIMESTAMP)"
+        )
+    )
+
+
+def downgrade():
+    op.drop_table("alert_settings")

--- a/web/wsgi.py
+++ b/web/wsgi.py
@@ -46,6 +46,30 @@ def get_pcc_access_key():
 
 
 @app.cli.command()
+def list_online_devices():
+    """List all activated computers that are currently online."""
+    from app.models import Computer
+    from app.models.computer import ComputerStatus
+
+    computers = (
+        models.Computer.query.filter(models.Computer.activated.is_(True))
+        .order_by(models.Computer.computer_name)
+        .all()
+    )
+    online = [c for c in computers if c.status in (ComputerStatus.ONLINE, ComputerStatus.ONLINE_NO_BACKUP)]
+
+    if not online:
+        print("No online devices.")
+        return
+
+    print(f"Online devices ({len(online)}):")
+    for c in online:
+        location = c.location_name or "-"
+        company = c.company_name or "-"
+        print(f"  {c.computer_name} | {location} | {company} | {c.status.value}")
+
+
+@app.cli.command()
 def clean_old_logs():
     from app.controllers import clean_old_logs
 


### PR DESCRIPTION
Introduce a global AlertSettings model and UI to manage support recipient emails (form, view, template, and admin link). Add alerts_paused boolean to Computer (model, admin view, drizzle schema) with corresponding Alembic migrations. Update alert controllers to read support emails from DB and to skip paused computers; include company info in alert emails. Harden file API last-time update with try/catch and return a 500 response on DB update failure. Add a CLI command to list online devices and register the alert_setup blueprint in app factory.